### PR TITLE
Fix to avoid errors due to Community Rating

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -193,7 +193,11 @@ public class Scraper
 
                 currFileObj.RunTime = (int)((float)episode.RunTimeTicks / 10000 / 60000);
                 currFileObj.OfficialRating = series.OfficialRating;
-                currFileObj.CommunityRating = series.CommunityRating;
+
+                if (series.CommunityRating is not null)
+                {
+                    currFileObj.CommunityRating = (int)series.CommunityRating;
+                }
 
                 if (!InDatabase("CurrRunData", currFileObj.Filename.Replace("'", string.Empty, StringComparison.Ordinal)) && 
                     !InDatabase("CurrNewsletterData", currFileObj.Filename.Replace("'", string.Empty, StringComparison.Ordinal)) && 


### PR DESCRIPTION
Hi,

Thanks for your fork of that plugin, it allows me to use it with my self-hosted mail.

While running, the scraper was sending errors like this on some of my library contents and failing :

[NLP]: [2025-03-16] :: [13:11:36] - [ERR] An error has occured: Error: SQLitePCL.pretty.SQLiteException: 14 values for 13 columns
   at SQLitePCL.pretty.SQLiteException.Throw(Int32 rc, Int32 extended, String msg)
   at SQLitePCL.pretty.SQLiteException.CheckOk(sqlite3 db, Int32 rc)
   at SQLitePCL.pretty.SQLiteDatabaseConnection.PrepareStatement(String sql, String& tail)
   at SQLitePCL.pretty.DatabaseConnection.PrepareStatement(IDatabaseConnection This, String sql)
   at SQLitePCL.pretty.DatabaseConnection.Execute(IDatabaseConnection This, String sql)
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.BuildObjs(List`1 items, String type)
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.BuildJsonObjsToCurrScanfile()
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.GetSeriesData()

due to the fact that it was trying to insert a line like this :

INSERT INTO CurrRunData (Filename, Title, Season, Episode, SeriesOverview, ImageURL, ItemID, PosterPath, Type, PremiereYear, RunTime, OfficialRating, CommunityRating) VALUES ('
/123.mp4','Serie name',0,4,'Overview of the serie','','483b094f92c1775837283820166b5dbd','/var/lib/jellyfin/metadata/library/48/483b094f92c1775837283820166b5dbd/poster.jpg
','Series','2021',44,'FR-18',6,9);

6,9 being the Community Rating found for the episode, but as it contains a comma, the insert fails.

So I converted the value into an int but then I got

[ERR] An error has occured: System.InvalidOperationException: Nullable object must have a value.
   at System.Nullable`1.get_Value()
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.BuildObjs(List`1 items, String type)
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.BuildJsonObjsToCurrScanfile()
   at Jellyfin.Plugin.Newsletters.Scripts.SCRAPER.Scraper.GetSeriesData()

so I added a test to verify that the value is not null.

So far it has been able to scrap my entire library, so it's much better. Hope this helps other people.
